### PR TITLE
Deprecate inplace parameter on freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ from typing import List
 from gelidum import freeze_params
 
 @freeze_params(params={"list1", "list2"})
-def concat_lists_in(dest: List, list1: List, list2: List):
+def concat_lists(dest: List, list1: List, list2: List) -> List:
     dest = list1 + list2
+    return dest
 
 # Freeze dest, list1 and list2
 concat_lists_in([], list1=[1, 2, 3], list2=[4, 5, 6])

--- a/README.md
+++ b/README.md
@@ -51,28 +51,57 @@ the attributes of the instance.
 
 ### Freeze in the same object
 ```python
+from typing import List
 from gelidum import freeze
-your_frozen_object = freeze(your_object, inplace=True)
-assert(id(your_frozen_object), id(your_object))
+
+class Dummy(object):
+  def __init__(self, attr1: int, attr2: List):
+    self.attr1 = attr1
+    self.attr2 = attr2
+
+dummy = Dummy(1, [2, 3, 4])
+frozen_dummy = freeze(dummy, inplace=True)
+assert(id(dummy) == id(frozen_dummy))
 
 # Both raise exception
-your_object.attr1 = new_value
-your_frozen_object.attr1 = new_value
+new_value = 1
+dummy.attr1 = new_value
+frozen_dummy.attr1 = new_value
+
+# Both raise exception
+new_value_list = [1]
+dummy.attr2 = new_value_list
+frozen_dummy.attr2 = new_value_list
 ```
 
 ### Freeze in a new object
 
 #### Basic use
 ```python
+from typing import List
 from gelidum import freeze
+
+class Dummy(object):
+  def __init__(self, attr1: int, attr2: List):
+    self.attr1 = attr1
+    self.attr2 = attr2
+
+dummy = Dummy(1, [2, 3, 4])
 # inplace=False by default
-your_frozen_object = freeze(your_object, inplace=False)
+frozen_dummy = freeze(dummy)
+assert(id(dummy) != id(frozen_dummy))
 
-# It doesn't raise an exception, mutable object
-your_object.attr1 = new_value
+# inplace=False by default
+frozen_object_dummy2 = freeze(dummy, inplace=False)
 
-# Raises exception, immutable object
-your_frozen_object.attr1 = new_value
+# It doesn't raise an exception,
+# dummy keeps being a mutable object
+new_attr1_value = 99
+dummy.attr1 = new_attr1_value
+
+# Raises exception,
+# frozen_dummy is an immutable object
+frozen_dummy.attr1 = new_attr1_value
 ```
 
 #### What to do when trying to update an attribute

--- a/gelidum/decorators.py
+++ b/gelidum/decorators.py
@@ -10,10 +10,10 @@ def freeze_params(params: Optional[Iterable[str]] = None):
         """Freeze all input params of a method"""
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            func_args = tuple([freeze(arg, inplace=False)
+            func_args = tuple([freeze(arg, on_freeze="copy")
                                for arg in args])
             func_kwargs = {
-                kwarg_name: freeze(kwarg, inplace=False)
+                kwarg_name: freeze(kwarg, on_freeze="copy")
                 if kwarg_name in params else kwarg
                 for kwarg_name, kwarg in kwargs.items()
             }
@@ -38,7 +38,7 @@ def freeze_final(func):
         }
         func_args = tuple([
             (
-                freeze(arg, inplace=False)
+                freeze(arg, on_freeze="copy")
                 if arg_index in unnamed_params_to_freeze else
                 arg
             )
@@ -46,7 +46,7 @@ def freeze_final(func):
             ])
         func_kwargs = {
             kwarg_name: (
-                freeze(kwarg, inplace=False)
+                freeze(kwarg, on_freeze="copy")
                 if kwarg_name in named_params_to_freeze else
                 kwarg
             )

--- a/gelidum/decorators.py
+++ b/gelidum/decorators.py
@@ -28,12 +28,14 @@ def freeze_final(func):
     def wrapper(*args, **kwargs):
         unnamed_params_to_freeze: Set[str] = {
             i
-            for i, (param_name, param_typing) in enumerate(func.__annotations__.items())
+            for i, (param_name, param_typing) in
+            enumerate(func.__annotations__.items())
             if str(param_typing).startswith("typing.Final")
         }
         named_params_to_freeze: Set[str] = {
             param_name
-            for param_name, param_typing in func.__annotations__.items()
+            for param_name, param_typing in
+            func.__annotations__.items()
             if str(param_typing).startswith("typing.Final")
         }
         func_args = tuple([

--- a/gelidum/freeze.py
+++ b/gelidum/freeze.py
@@ -137,4 +137,3 @@ def __on_freeze_func(on_freeze: Union[str, OnFreezeFuncType]) -> OnFreezeFuncTyp
             f"Invalid value for on_freeze parameter, '{on_freeze}' found, "
             f"only 'copy', 'inplace' or a function are valid options"
         )
-

--- a/gelidum/freeze.py
+++ b/gelidum/freeze.py
@@ -1,15 +1,56 @@
 import copy
 import io
 import sys
+import warnings
 from io import TextIOWrapper, BufferedWriter
-from typing import List, Tuple, Set, Dict, Any
+from typing import List, Tuple, Set, Dict, Any, Optional, Union, Type, TypeVar
 from frozendict import frozendict
-from gelidum.frozen import make_frozen_class
+from gelidum.frozen import make_frozen_class, FrozenBase
 from gelidum.utils import isbuiltin
-from gelidum.typing import OnUpdateType
+from gelidum.typing import OnFreezeFuncType, OnUpdateFuncType
+
+T = TypeVar('T')
+
+_FrozenType = Optional[
+    Union[
+        bool, int, float, bytes, complex, str,
+        bytes, frozendict, tuple, frozenset,
+        Type[FrozenBase], T
+    ]
+]
 
 
-def freeze(obj: Any, on_update: OnUpdateType = "exception", inplace: bool = False) -> Any:
+def freeze(
+        obj: T,
+        on_update: Union[str, OnUpdateFuncType] = "exception",
+        on_freeze: Union[str, OnFreezeFuncType] = "copy",
+        inplace: Optional[bool] = None
+        ) -> _FrozenType:
+
+    # inplace argument will be removed from freeze in the next major version
+    if isinstance(inplace, bool):
+        warnings.warn(
+            DeprecationWarning(
+                "Use of inplace is deprecated and will be removed in next major version"
+            )
+        )
+        if inplace:
+            on_freeze = __on_freeze_func(on_freeze="inplace")
+        else:
+            on_freeze = __on_freeze_func(on_freeze="copy")
+
+    else:
+        if isinstance(on_freeze, str):
+            on_freeze = __on_freeze_func(on_freeze=on_freeze)
+        elif not callable(on_freeze):
+            raise ValueError("on_freeze must be a string or a callable function with one parameter")
+
+    return __freeze(obj=obj, on_update=on_update, on_freeze=on_freeze)
+
+
+def __freeze(obj: Any, on_update: OnUpdateFuncType,
+             on_freeze: OnFreezeFuncType) -> Any:
+
     if isbuiltin(obj):
         return obj
 
@@ -18,10 +59,10 @@ def freeze(obj: Any, on_update: OnUpdateType = "exception", inplace: bool = Fals
     this_module = sys.modules[__name__]
     if hasattr(this_module, freeze_func_name):
         freeze_func = getattr(this_module, freeze_func_name)
-        return freeze_func(obj, on_update=on_update, inplace=inplace)
+        return freeze_func(obj, on_update=on_update, on_freeze=on_freeze)
 
     if isinstance(obj, object):
-        return __freeze_object(obj, on_update=on_update, inplace=inplace)
+        return __freeze_object(obj, on_update=on_update, on_freeze=on_freeze)
 
     raise ValueError(f"object of type {obj.__class__} not frozen")
 
@@ -30,52 +71,73 @@ def __freeze_bytearray(obj: bytearray, *args, **kwargs) -> bytes:
     return bytes(obj)
 
 
-def __freeze_dict(obj: Dict, on_update: OnUpdateType = "exception",
-                  inplace: bool = False) -> frozendict:
-    return frozendict({key: freeze(value, on_update=on_update, inplace=inplace)
+def __freeze_dict(obj: Dict, on_update: OnUpdateFuncType,
+                  on_freeze: OnFreezeFuncType) -> frozendict:
+    return frozendict({key: __freeze(value, on_update=on_update, on_freeze=on_freeze)
                        for key, value in obj.items()})
 
 
-def __freeze_list(obj: List, on_update: OnUpdateType = "exception",
-                  inplace: bool = False) -> Tuple:
-    return tuple(freeze(item, on_update=on_update, inplace=inplace)
+def __freeze_list(obj: List, on_update: OnUpdateFuncType,
+                  on_freeze: OnFreezeFuncType) -> Tuple:
+    return tuple(__freeze(item, on_update=on_update, on_freeze=on_freeze)
                  for item in obj)
 
 
-def __freeze_tuple(obj: Tuple, on_update: OnUpdateType = "exception",
-                   inplace: bool = False) -> Tuple:
-    return tuple(freeze(item, on_update=on_update, inplace=inplace)
+def __freeze_tuple(obj: Tuple, on_update: OnUpdateFuncType,
+                   on_freeze: OnFreezeFuncType) -> Tuple:
+    return tuple(freeze(item, on_update=on_update, on_freeze=on_freeze)
                  for item in obj)
 
 
-def __freeze_set(obj: Set, on_update: OnUpdateType = "exception",
-                 inplace: bool = False) -> frozenset:
-    return frozenset([freeze(item, on_update=on_update, inplace=inplace)
+def __freeze_set(obj: Set, on_update: OnUpdateFuncType,
+                 on_freeze: OnFreezeFuncType) -> frozenset:
+    return frozenset([freeze(item, on_update=on_update, on_freeze=on_freeze)
                       for item in obj])
 
 
-def __freeze_TextIOWrapper(obj: TextIOWrapper, on_update: OnUpdateType = "exception",
-                           inplace: bool = False):
+def __freeze_TextIOWrapper(obj: TextIOWrapper, on_update: OnUpdateFuncType,
+                           on_freeze: OnFreezeFuncType) -> None:
     raise io.UnsupportedOperation("Text file handlers can't be frozen")
 
 
-def __freeze_BufferedWriter(obj: BufferedWriter, on_update: OnUpdateType = "exception",
-                            inplace: bool = False):
+def __freeze_BufferedWriter(obj: BufferedWriter, on_update: OnUpdateFuncType,
+                            on_freeze: OnFreezeFuncType) -> None:
     raise io.UnsupportedOperation("Binary file handlers can't be frozen")
 
 
-def __freeze_object(obj: object, on_update: OnUpdateType = "exception",
-                    inplace: bool = False) -> object:
-    if inplace:
-        frozen_obj = obj
-    else:
-        frozen_obj = copy.deepcopy(obj)
+def __freeze_object(obj: object, on_update: OnUpdateFuncType,
+                    on_freeze: OnFreezeFuncType) -> Type[FrozenBase]:
+
+    frozen_obj = on_freeze(obj)
     for attr, value in frozen_obj.__dict__.items():
         attr_value = getattr(frozen_obj, attr)
-        setattr(frozen_obj, attr, freeze(attr_value, on_update=on_update, inplace=inplace))
+        setattr(frozen_obj, attr, freeze(attr_value, on_update=on_update, on_freeze=on_freeze))
     frozen_obj.__class__ = make_frozen_class(
         klass=obj.__class__,
         attrs=list(obj.__dict__.keys()),
         on_update=on_update
     )
     return frozen_obj
+
+
+def __on_freeze_func(on_freeze: Union[str, OnFreezeFuncType]) -> OnFreezeFuncType:
+    if isinstance(on_freeze, str):
+        if on_freeze == "copy":
+            return lambda obj: copy.deepcopy(obj)
+        elif on_freeze == "inplace":
+            return lambda obj: obj
+        else:
+            raise AttributeError(
+                f"Invalid value for on_freeze parameter, '{on_freeze}' found, "
+                f"only 'copy', 'inplace' are valid options if passed a string."
+            )
+
+    elif callable(on_freeze):
+        return on_freeze
+
+    else:
+        raise AttributeError(
+            f"Invalid value for on_freeze parameter, '{on_freeze}' found, "
+            f"only 'copy', 'inplace' or a function are valid options"
+        )
+

--- a/gelidum/freeze.py
+++ b/gelidum/freeze.py
@@ -40,10 +40,7 @@ def freeze(
             on_freeze = __on_freeze_func(on_freeze="copy")
 
     else:
-        if isinstance(on_freeze, str):
-            on_freeze = __on_freeze_func(on_freeze=on_freeze)
-        elif not callable(on_freeze):
-            raise ValueError("on_freeze must be a string or a callable function with one parameter")
+        on_freeze = __on_freeze_func(on_freeze=on_freeze)
 
     return __freeze(obj=obj, on_update=on_update, on_freeze=on_freeze)
 
@@ -129,7 +126,7 @@ def __on_freeze_func(on_freeze: Union[str, OnFreezeFuncType]) -> OnFreezeFuncTyp
         else:
             raise AttributeError(
                 f"Invalid value for on_freeze parameter, '{on_freeze}' found, "
-                f"only 'copy', 'inplace' are valid options if passed a string."
+                f"only 'copy' and 'inplace' are valid options if passed a string"
             )
 
     elif callable(on_freeze):

--- a/gelidum/frozen.py
+++ b/gelidum/frozen.py
@@ -22,7 +22,7 @@ class FrozenBase(object):
     def __setattr__(self, key, value):
         self.__gelidum_on_update(
             frozen_obj=self,
-            message=f"Can't assign '{key}' on immutable instance",
+            message=f"Can't assign attribute '{key}' on immutable instance",
             key=key, value=value
         )
 

--- a/gelidum/frozen.py
+++ b/gelidum/frozen.py
@@ -21,41 +21,41 @@ class FrozenBase(object):
 
     def __setattr__(self, key, value):
         self.__gelidum_on_update(
-            obj=self,
+            frozen_obj=self,
             message=f"Can't assign '{key}' on immutable instance",
             key=key, value=value
         )
 
     def __set__(self, *args, **kwargs):
         self.__gelidum_on_update(
-            obj=self,
+            frozen_obj=self,
             message="Can't assign setter on immutable instance",
             *args, **kwargs
         )
 
     def __delattr__(self, name):
         self.__gelidum_on_update(
-            obj=self,
+            frozen_obj=self,
             message=f"Can't delete attribute '{name}' on immutable instance",
             name=name
         )
 
     def __setitem__(self, key, value):
         self.__gelidum_on_update(
-            obj=self,
+            frozen_obj=self,
             message="Can't set key on immutable instance",
             key=key, value=value
         )
 
     def __delitem__(self, key):
         self.__gelidum_on_update(
-            obj=self,
+            frozen_obj=self,
             message="Can't delete key on immutable instance",
             key=key)
 
     def __reversed__(self):
         self.__gelidum_on_update(
-            obj=self,
+            frozen_obj=self,
             message="Can't reverse on immutable instance"
         )
 

--- a/gelidum/frozen.py
+++ b/gelidum/frozen.py
@@ -156,4 +156,3 @@ def make_frozen_class(klass: Type[object], attrs: List[str],
         )
 
     return frozen_class
-

--- a/gelidum/frozen.py
+++ b/gelidum/frozen.py
@@ -64,7 +64,9 @@ __FROZEN_CLASSES: Dict[str, Type[FrozenBase]] = dict()
 __FROZEN_CLASSES_LOCK = threading.Lock()
 
 
-def __store_frozen_class(klass: Type[object], frozen_class: Type[FrozenBase]) -> None:
+def __store_frozen_class(
+        klass: Type[object], frozen_class: Type[FrozenBase]
+) -> None:
     """
     Add a frozen class to this module.
     Required for pickle serialization as only objects of non-dynamic
@@ -85,9 +87,14 @@ def clear_frozen_classes() -> None:
         __FROZEN_CLASSES.clear()
 
 
-def __create_frozen_class(klass: Type[object], attrs: List[str],
-                          on_update_func: GelidumOnUpdateType) -> Type[FrozenBase]:
-    camel_case_module = klass.__module__.title().replace(".", "").replace("_", "")
+def __create_frozen_class(
+        klass: Type[object],
+        attrs: List[str],
+        on_update_func: GelidumOnUpdateType
+) -> Type[FrozenBase]:
+    camel_case_module = (
+        klass.__module__.title().replace(".", "").replace("_", "")
+    )
     frozen_class_name = f"Frozen{klass.__name__}From{camel_case_module}"
     frozen_class: Type[FrozenBase] = cast(
         Type[FrozenBase],
@@ -100,7 +107,8 @@ def __create_frozen_class(klass: Type[object], attrs: List[str],
                     'get_gelidum_hot_class_name': lambda _: klass.__name__,
                     'get_gelidum_hot_class_module': lambda _: klass.__module__,
                     '_FrozenBase__gelidum_on_update':
-                        lambda _self, *args, **kwargs: on_update_func(*args, **kwargs),
+                        lambda _self, *args, **kwargs:
+                        on_update_func(*args, **kwargs),
                     **{attr: None for attr in attrs}
                 }
             }
@@ -139,7 +147,8 @@ def __on_update_func(on_update: OnUpdateFuncType) -> GelidumOnUpdateType:
     else:
         raise AttributeError(
             f"Invalid value for on_update parameter, '{on_update}' found, "
-            f"only 'exception', 'warning', 'nothing' or a function are valid options"
+            f"only 'exception', 'warning', 'nothing' or a function are "
+            f"valid options"
         )
 
 

--- a/gelidum/frozen.py
+++ b/gelidum/frozen.py
@@ -43,14 +43,14 @@ class FrozenBase(object):
     def __setitem__(self, key, value):
         self.__gelidum_on_update(
             frozen_obj=self,
-            message="Can't set key on immutable instance",
+            message=f"Can't set key '{key}' on immutable instance",
             key=key, value=value
         )
 
     def __delitem__(self, key):
         self.__gelidum_on_update(
             frozen_obj=self,
-            message="Can't delete key on immutable instance",
+            message=f"Can't delete key '{key}' on immutable instance",
             key=key)
 
     def __reversed__(self):

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import typing
 from typing import Any, Callable, Union, Type
 
@@ -12,7 +13,7 @@ try:
 except AttributeError:
     Final = typing.Final
 
-_FrozenBase = Type["gelidum.frozen.FrozenBase"]
+_FrozenBase = Type["FrozenBase"]
 _GelidumOnUpdateWithMessageType = Callable[[_FrozenBase, str], None]
 _GelidumOnUpdateWithFuncType = Callable[[_FrozenBase, str, ...], None]
 

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -1,7 +1,7 @@
 import typing
 from typing import Any, Callable, Union, Type, TYPE_CHECKING
 if TYPE_CHECKING:
-    from gelidum.frozen import FrozenBase
+    from gelidum.frozen import FrozenBase  # noqa
 
 try:
     _SpecialForm = getattr(typing, "_SpecialForm")

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, Type
 
 
 try:
@@ -12,9 +12,9 @@ try:
 except AttributeError:
     Final = typing.Final
 
-
-_GelidumOnUpdateWithMessageType = Callable[[Any, str], None]
-_GelidumOnUpdateWithFuncType = Callable[[Any, str, ...], None]
+_FrozenBase = Type["FrozenBase"]
+_GelidumOnUpdateWithMessageType = Callable[[_FrozenBase, str], None]
+_GelidumOnUpdateWithFuncType = Callable[[_FrozenBase, str, ...], None]
 
 GelidumOnUpdateType = Union[
     _GelidumOnUpdateWithMessageType,
@@ -22,7 +22,7 @@ GelidumOnUpdateType = Union[
 ]
 
 
-OnUpdateFuncType = Callable[[str, Any], None]
+OnUpdateFuncType = Callable[[_FrozenBase, str, ...], None]
 
 
 OnFreezeFuncType = Callable[[Any], Any]

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -1,6 +1,7 @@
 import typing
 from typing import Any, Callable, Union
 
+
 try:
     _SpecialForm = getattr(typing, "_SpecialForm")
 
@@ -12,13 +13,16 @@ except AttributeError:
     Final = typing.Final
 
 
-_GelidumOnUpdateWithMessageType = Callable[[str], None]
-_GelidumOnUpdateWithFuncType = Callable[[str, ...], None]
+_GelidumOnUpdateWithMessageType = Callable[[Any, str], None]
+_GelidumOnUpdateWithFuncType = Callable[[Any, str, ...], None]
 
 GelidumOnUpdateType = Union[
     _GelidumOnUpdateWithMessageType,
     _GelidumOnUpdateWithFuncType
 ]
 
-_OnUpdateFuncType = Callable[[str, Any], None]
-OnUpdateType = Union[_OnUpdateFuncType, str]
+
+OnUpdateFuncType = Callable[[str, Any], None]
+
+
+OnFreezeFuncType = Callable[[Any], Any]

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -12,7 +12,7 @@ try:
 except AttributeError:
     Final = typing.Final
 
-_FrozenBase = Type["FrozenBase"]
+_FrozenBase = Type["gelidum.frozen.FrozenBase"]
 _GelidumOnUpdateWithMessageType = Callable[[_FrozenBase, str], None]
 _GelidumOnUpdateWithFuncType = Callable[[_FrozenBase, str, ...], None]
 

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -1,7 +1,7 @@
-from __future__ import annotations
 import typing
-from typing import Any, Callable, Union, Type
-
+from typing import Any, Callable, Union, Type, TYPE_CHECKING
+if TYPE_CHECKING:
+    from gelidum.frozen import FrozenBase
 
 try:
     _SpecialForm = getattr(typing, "_SpecialForm")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License"
     ],
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(requirements_path) as requirements_file:
 
 setup(
     name="gelidum",
-    version="0.3.4",
+    version="0.4.0",
     author="Diego J. Romero López",
     author_email="diegojromerolopez@gmail.com",
     description="Freeze your python objects",

--- a/tests/gelidum_tests/test_decorators.py
+++ b/tests/gelidum_tests/test_decorators.py
@@ -42,7 +42,7 @@ class TestDecorator(unittest.TestCase):
 
         dummy.attr = 100
 
-        self.assertEqual("Can't assign 'attr' on immutable instance",
+        self.assertEqual("Can't assign attribute 'attr' on immutable instance",
                          str(context.exception))
         self.assertEqual(100, dummy.attr)
 
@@ -84,7 +84,7 @@ class TestDecorator(unittest.TestCase):
         for future_i in futures:
             with self.assertRaises(FrozenException) as context:
                 future_i.result()
-            self.assertEqual("Can't assign 'attr' on immutable instance",
+            self.assertEqual("Can't assign attribute 'attr' on immutable instance",
                              str(context.exception))
             future_count += 1
         self.assertEqual(2, future_count)
@@ -127,9 +127,9 @@ class TestDecorator(unittest.TestCase):
         with self.assertRaises(FrozenException) as context_named_arguments:
             product_bad_implementation(one=Number(1), two=Number(2), three=Number(3))
 
-        self.assertEqual("Can't assign 'value' on immutable instance",
+        self.assertEqual("Can't assign attribute 'value' on immutable instance",
                          str(context_unnamed_arguments.exception))
-        self.assertEqual("Can't assign 'value' on immutable instance",
+        self.assertEqual("Can't assign attribute 'value' on immutable instance",
                          str(context_some_named_arguments.exception))
-        self.assertEqual("Can't assign 'value' on immutable instance",
+        self.assertEqual("Can't assign attribute 'value' on immutable instance",
                          str(context_named_arguments.exception))

--- a/tests/gelidum_tests/test_freeze.py
+++ b/tests/gelidum_tests/test_freeze.py
@@ -81,9 +81,9 @@ class TestFreeze(unittest.TestCase):
         with self.assertRaises(FrozenException) as context_inplace:
             frozen_dummy_inplace.attr2 = "2"
 
-        self.assertEqual("Can't assign 'attr1' on immutable instance",
+        self.assertEqual("Can't assign attribute 'attr1' on immutable instance",
                          str(context_on_freeze_copy.exception))
-        self.assertEqual("Can't assign 'attr2' on immutable instance",
+        self.assertEqual("Can't assign attribute 'attr2' on immutable instance",
                          str(context_inplace.exception))
         self.assertEqual(id(dummy), id(frozen_dummy_inplace))
         self.assertNotEqual(id(dummy), id(frozen_dummy_on_freeze_copy))
@@ -146,9 +146,9 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(3, frozen_dummy._Dummy__attr3)
         self.assertListEqual(
             [
-                "Can't assign 'attr1' on immutable instance",
-                "Can't assign '_attr2' on immutable instance",
-                "Can't assign '_Dummy__attr3' on immutable instance"
+                "Can't assign attribute 'attr1' on immutable instance",
+                "Can't assign attribute '_attr2' on immutable instance",
+                "Can't assign attribute '_Dummy__attr3' on immutable instance"
             ],
             [str(warn.message) for warn in caught_warnings]
         )
@@ -218,11 +218,11 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual((Dummy, FrozenBase), frozen_dummy.__class__.__bases__)
         self.assertEqual(1, frozen_dummy.attr)
         self.assertEqual(
-            "Can't assign 'attr' on immutable instance",
+            "Can't assign attribute 'attr' on immutable instance",
             str(setattr_context.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr' on immutable instance",
+            "Can't assign attribute 'attr' on immutable instance",
             str(set_context.exception)
         )
         self.assertEqual(
@@ -276,15 +276,15 @@ class TestFreeze(unittest.TestCase):
         expected_writing_tries = [
             {'args': (),
              'kwargs': {'key': 'attr1', 'value': 99, 'frozen_obj': frozen_dummy},
-             'message': "Can't assign 'attr1' on immutable instance",
+             'message': "Can't assign attribute 'attr1' on immutable instance",
              'time': fixed_utcnow},
             {'args': (),
              'kwargs': {'key': '_attr2', 'value': 99, 'frozen_obj': frozen_dummy},
-             'message': "Can't assign '_attr2' on immutable instance",
+             'message': "Can't assign attribute '_attr2' on immutable instance",
              'time': fixed_utcnow},
             {'args': (),
              'kwargs': {'key': '_Dummy__attr3', 'value': 99, 'frozen_obj': frozen_dummy},
-             'message': "Can't assign '_Dummy__attr3' on immutable instance",
+             'message': "Can't assign attribute '_Dummy__attr3' on immutable instance",
              'time': fixed_utcnow}
         ]
 
@@ -352,7 +352,7 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(2, frozen_dummy.attr2)
         self.assertEqual(3, frozen_dummy.attr3)
         self.assertEqual(
-            unittest.mock.call("Can't assign 'attr1' on immutable instance"),
+            unittest.mock.call("Can't assign attribute 'attr1' on immutable instance"),
             mock_logger.warning.call_args
         )
         self.assertEqual(id(dummy), id(update_try_recorder.original_obj))
@@ -393,39 +393,39 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(2, frozen_dummy._attr2)
         self.assertEqual(3, frozen_dummy._Dummy__attr3)
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_assign_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_assign_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_assign_attr3.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_inc_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_inc_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_inc_attr3.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_dec_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_dec_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_dec_attr3.exception)
         )
 
@@ -464,39 +464,39 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(2, frozen_dummy._attr2)
         self.assertEqual(3, frozen_dummy._Dummy__attr3)
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_assign_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_assign_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_assign_attr3.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_inc_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_inc_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_inc_attr3.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_dec_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_dec_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_dec_attr3.exception)
         )
 
@@ -545,35 +545,35 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(12, frozen_deep_dummy.dummy1._attr2)
         self.assertEqual(13, frozen_deep_dummy.dummy1._Dummy__attr3)
         self.assertEqual(
-            "Can't assign 'dummy1' on immutable instance",
+            "Can't assign attribute 'dummy1' on immutable instance",
             str(context_exc_dummy1.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_dummy1_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_dummy1_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_dummy1_attr3.exception)
         )
         self.assertEqual(
-            "Can't assign 'dummy1' on immutable instance",
+            "Can't assign attribute 'dummy1' on immutable instance",
             str(context_exc_setattr_dummy1.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_setattr_dummy1_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_setattr_dummy1_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_setattr_dummy1_attr3.exception)
         )
 
@@ -622,35 +622,35 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(12, frozen_deep_dummy.dummy1._attr2)
         self.assertEqual(13, frozen_deep_dummy.dummy1._Dummy__attr3)
         self.assertEqual(
-            "Can't assign 'dummy1' on immutable instance",
+            "Can't assign attribute 'dummy1' on immutable instance",
             str(context_exc_dummy1.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_dummy1_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_dummy1_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_dummy1_attr3.exception)
         )
         self.assertEqual(
-            "Can't assign 'dummy1' on immutable instance",
+            "Can't assign attribute 'dummy1' on immutable instance",
             str(context_exc_setattr_dummy1.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context_exc_setattr_dummy1_attr1.exception)
         )
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance",
+            "Can't assign attribute '_attr2' on immutable instance",
             str(context_exc_setattr_dummy1_attr2.exception)
         )
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance",
+            "Can't assign attribute '_Dummy__attr3' on immutable instance",
             str(context_exc_setattr_dummy1_attr3.exception)
         )
 
@@ -743,7 +743,7 @@ class TestFreeze(unittest.TestCase):
         with self.assertRaises(FrozenException) as context:
             frozen_dummy.new_attribute = 99
         self.assertEqual(
-            "Can't assign 'new_attribute' on immutable instance", str(context.exception))
+            "Can't assign attribute 'new_attribute' on immutable instance", str(context.exception))
 
     def test_cannot_use_modifying_attribute_method_in_frozen_object(self):
         class Dummy(object):
@@ -771,11 +771,11 @@ class TestFreeze(unittest.TestCase):
             frozen_dummy.inc_attr3()
 
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance", str(context1.exception))
+            "Can't assign attribute 'attr1' on immutable instance", str(context1.exception))
         self.assertEqual(
-            "Can't assign '_attr2' on immutable instance", str(context2.exception))
+            "Can't assign attribute '_attr2' on immutable instance", str(context2.exception))
         self.assertEqual(
-            "Can't assign '_Dummy__attr3' on immutable instance", str(context3.exception))
+            "Can't assign attribute '_Dummy__attr3' on immutable instance", str(context3.exception))
 
     def test_json(self):
         data_list = [{"a": 1, "b": 2}, {"a": 11, "b": 22}]
@@ -800,7 +800,7 @@ class TestFreeze(unittest.TestCase):
             unpickled_frozen_dummy.attr = 8
 
         self.assertEqual(
-            "Can't assign 'attr' on immutable instance",
+            "Can't assign attribute 'attr' on immutable instance",
             str(context.exception)
         )
         self.assertEqual(1, frozen_dummy.attr, unpickled_frozen_dummy.attr)
@@ -832,19 +832,19 @@ class TestFreeze(unittest.TestCase):
             unpickled_frozen_dummy2.get_gelidum_hot_class_module = 99
 
         self.assertEqual(
-            "Can't assign 'attr1' on immutable instance",
+            "Can't assign attribute 'attr1' on immutable instance",
             str(context1.exception)
         )
         self.assertEqual(
-            "Can't assign 'attr2' on immutable instance",
+            "Can't assign attribute 'attr2' on immutable instance",
             str(context2.exception)
         )
         self.assertEqual(
-            "Can't assign 'get_gelidum_hot_class_module' on immutable instance",
+            "Can't assign attribute 'get_gelidum_hot_class_module' on immutable instance",
             str(context1_get_gelidum_hot_class_module.exception)
         )
         self.assertEqual(
-            "Can't assign 'get_gelidum_hot_class_module' on immutable instance",
+            "Can't assign attribute 'get_gelidum_hot_class_module' on immutable instance",
             str(context2_get_gelidum_hot_class_module.exception)
         )
         self.assertEqual(1, frozen_dummy1.attr1, unpickled_frozen_dummy1.attr1)

--- a/tests/gelidum_tests/test_freeze.py
+++ b/tests/gelidum_tests/test_freeze.py
@@ -1,12 +1,15 @@
+import copy
 import datetime
 import io
 import json
+import logging
 import pickle
 import sys
 import tempfile
+import threading
 import unittest
 import warnings
-from typing import Dict
+from typing import Dict, List
 from unittest.mock import patch
 from frozendict import frozendict
 from gelidum import FrozenException
@@ -40,6 +43,17 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(
             ("one", 2, "three"), freeze(["one", 2, "three"]))
 
+    def test_freeze_list_inplace_true_deprecated_parameter(self):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            frozen_list = freeze(["one", 2, "three"], inplace=True)
+
+        self.assertEqual(("one", 2, "three"), frozen_list)
+        self.assertEqual(1, len(caught_warnings))
+        self.assertEqual(
+            "Use of inplace is deprecated and will be removed in next major version",
+            str(caught_warnings[0].message)
+        )
+
     def test_freeze_tuple(self):
         self.assertEqual(
             ("one", 2, "three"), freeze(("one", 2, "three")))
@@ -58,23 +72,23 @@ class TestFreeze(unittest.TestCase):
             attr3: str = "0"
 
         dummy = Dummy(attr1="1", attr2="2", attr3="3")
-        frozen_dummy_not_inplace = freeze(dummy, inplace=False)
-        frozen_dummy_inplace = freeze(dummy, inplace=True)
+        frozen_dummy_on_freeze_copy = freeze(dummy, on_freeze="copy")
+        frozen_dummy_inplace = freeze(dummy, on_freeze="inplace")
 
-        with self.assertRaises(FrozenException) as context_not_inplace:
-            frozen_dummy_not_inplace.attr1 = "2"
+        with self.assertRaises(FrozenException) as context_on_freeze_copy:
+            frozen_dummy_on_freeze_copy.attr1 = "2"
 
         with self.assertRaises(FrozenException) as context_inplace:
             frozen_dummy_inplace.attr2 = "2"
 
         self.assertEqual("Can't assign 'attr1' on immutable instance",
-                         str(context_not_inplace.exception))
+                         str(context_on_freeze_copy.exception))
         self.assertEqual("Can't assign 'attr2' on immutable instance",
                          str(context_inplace.exception))
         self.assertEqual(id(dummy), id(frozen_dummy_inplace))
-        self.assertNotEqual(id(dummy), id(frozen_dummy_not_inplace))
+        self.assertNotEqual(id(dummy), id(frozen_dummy_on_freeze_copy))
 
-    def test_freeze_simple_object_on_update_warning_inplace(self):
+    def test_freeze_simple_object_inplace_true_deprecated_parameter(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -82,7 +96,43 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, on_update="warning", inplace=True)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            frozen_dummy = freeze(dummy, on_update="exception", inplace=True)
+
+        self.assertEqual(id(dummy), id(frozen_dummy))
+        self.assertEqual(1, len(caught_warnings))
+        self.assertEqual(
+            "Use of inplace is deprecated and will be removed in next major version",
+            str(caught_warnings[0].message)
+        )
+
+    def test_freeze_simple_object_inplace_false_deprecated_parameter(self):
+        class Dummy(object):
+            def __init__(self, attr1: int, attr2: int, attr3: int):
+                self.attr1 = attr1
+                self._attr2 = attr2
+                self.__attr3 = attr3
+
+        dummy = Dummy(attr1=1, attr2=2, attr3=3)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            frozen_dummy = freeze(dummy, on_update="exception", inplace=False)
+
+        self.assertNotEqual(id(dummy), id(frozen_dummy))
+        self.assertEqual(1, len(caught_warnings))
+        self.assertEqual(
+            "Use of inplace is deprecated and will be removed in next major version",
+            str(caught_warnings[0].message)
+        )
+
+    def test_freeze_simple_object_on_update_warning_on_freeze_inplace(self):
+        class Dummy(object):
+            def __init__(self, attr1: int, attr2: int, attr3: int):
+                self.attr1 = attr1
+                self._attr2 = attr2
+                self.__attr3 = attr3
+
+        dummy = Dummy(attr1=1, attr2=2, attr3=3)
+        frozen_dummy = freeze(dummy, on_update="warning", on_freeze="inplace")
 
         with warnings.catch_warnings(record=True) as caught_warnings:
             frozen_dummy.attr1 = 99
@@ -103,7 +153,7 @@ class TestFreeze(unittest.TestCase):
             [str(warn.message) for warn in caught_warnings]
         )
 
-    def test_freeze_simple_object_on_update_nothing_inplace(self):
+    def test_freeze_simple_object_on_update_nothing_on_freeze_inplace(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -111,7 +161,7 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, on_update="nothing", inplace=True)
+        frozen_dummy = freeze(dummy, on_update="nothing", on_freeze="inplace")
         frozen_dummy.attr1 = 99
         frozen_dummy._attr2 = 99
         frozen_dummy._Dummy__attr3 = 99
@@ -123,18 +173,21 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(3, frozen_dummy._Dummy__attr3)
 
     @patch("datetime.datetime")
-    def test_freeze_simple_object_on_update_func_inplace(self, mock_datetime):
+    def test_freeze_simple_object_on_update_function_freeze_inplace(self, mock_datetime):
         fixed_utcnow = datetime.datetime(2021, 6, 16, 14, 20, 56, 809581)
         mock_datetime.utcnow = unittest.mock.Mock(return_value=fixed_utcnow)
 
         expected_write_tries = [
-            {'args': (), 'kwargs': {'key': 'attr1', 'value': 99},
+            {'args': (),
+             'kwargs': {'key': 'attr1', 'value': 99, 'obj': unittest.mock.ANY},
              'message': "Can't assign 'attr1' on immutable instance",
              'time': fixed_utcnow},
-            {'args': (), 'kwargs': {'key': '_attr2', 'value': 99},
+            {'args': (),
+             'kwargs': {'key': '_attr2', 'value': 99, 'obj': unittest.mock.ANY},
              'message': "Can't assign '_attr2' on immutable instance",
              'time': fixed_utcnow},
-            {'args': (), 'kwargs': {'key': '_Dummy__attr3', 'value': 99},
+            {'args': (),
+             'kwargs': {'key': '_Dummy__attr3', 'value': 99, 'obj': unittest.mock.ANY},
              'message': "Can't assign '_Dummy__attr3' on immutable instance",
              'time': fixed_utcnow}
         ]
@@ -158,8 +211,8 @@ class TestFreeze(unittest.TestCase):
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
         frozen_dummy = freeze(
             dummy,
-            on_update=on_update_func ,
-            inplace=True
+            on_update=on_update_func,
+            on_freeze="inplace"
         )
         frozen_dummy.attr1 = 99
         frozen_dummy._attr2 = 99
@@ -172,7 +225,59 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(3, frozen_dummy._Dummy__attr3)
         self.assertListEqual(expected_write_tries, write_tries)
 
-    def test_freeze_simple_object_inplace(self):
+    @patch("logging.Logger")
+    def test_freeze_simple_object_on_update_func_store_update_tries(self, mock_logger):
+        class Dummy(object):
+            def __init__(self, attr1: int, attr2: int, attr3: int):
+                self.attr1 = attr1
+                self.attr2 = attr2
+                self.attr3 = attr3
+
+        class FrozenDummyUpdateTryRecorder(object):
+            def __init__(self, log: logging.Logger):
+                self.log = log
+                self.lock = threading.Lock()
+                self.written_tries: List[Dict] = []
+                self.original_obj = None
+
+            def on_freeze(self, obj: object) -> object:
+                frozen_object = copy.deepcopy(obj)
+                self.original_obj = obj
+                return frozen_object
+
+            def on_update(self, obj: object, message: str, *args, **kwargs):
+                self.log.warning(message)
+                with self.lock:
+                    self.written_tries.append({
+                        "args": args,
+                        "kwargs": kwargs,
+                        "datetime": datetime.datetime.utcnow()
+                    })
+
+        update_try_recorder = FrozenDummyUpdateTryRecorder(
+            log=mock_logger
+        )
+
+        dummy = Dummy(attr1=1, attr2=2, attr3=3)
+        frozen_dummy = freeze(
+            dummy,
+            on_freeze=update_try_recorder.on_freeze,
+            on_update=update_try_recorder.on_update
+        )
+
+        frozen_dummy.attr1 = 99
+
+        self.assertNotEqual(id(dummy), id(frozen_dummy))
+        self.assertEqual((Dummy, FrozenBase), frozen_dummy.__class__.__bases__)
+        self.assertEqual(1, frozen_dummy.attr1)
+        self.assertEqual(2, frozen_dummy.attr2)
+        self.assertEqual(3, frozen_dummy.attr3)
+        self.assertEqual(
+            unittest.mock.call("Can't assign 'attr1' on immutable instance"),
+            mock_logger.warning.call_args
+        )
+
+    def test_freeze_simple_object_on_freeze_inplace(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -180,7 +285,7 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, inplace=True)
+        frozen_dummy = freeze(dummy, on_freeze="inplace")
 
         with self.assertRaises(FrozenException) as context_exc_assign_attr1:
             frozen_dummy.attr1 = 99
@@ -243,7 +348,7 @@ class TestFreeze(unittest.TestCase):
             str(context_exc_dec_attr3.exception)
         )
 
-    def test_freeze_simple_object_not_inplace(self):
+    def test_freeze_simple_object_on_freeze_copy(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -251,7 +356,7 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, inplace=False)
+        frozen_dummy = freeze(dummy, on_freeze="copy")
 
         with self.assertRaises(FrozenException) as context_exc_assign_attr1:
             frozen_dummy.attr1 = 99
@@ -314,7 +419,7 @@ class TestFreeze(unittest.TestCase):
             str(context_exc_dec_attr3.exception)
         )
 
-    def test_freeze_deep_object_inplace(self):
+    def test_freeze_deep_object_on_freeze_inplace(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -333,7 +438,7 @@ class TestFreeze(unittest.TestCase):
             dummy3=Dummy(attr1=31, attr2=32, attr3=33)
         )
 
-        frozen_deep_dummy = freeze(deep_dummy, inplace=True)
+        frozen_deep_dummy = freeze(deep_dummy, on_freeze="inplace")
 
         with self.assertRaises(FrozenException) as context_exc_dummy1:
             frozen_deep_dummy.dummy1 = 99
@@ -391,7 +496,7 @@ class TestFreeze(unittest.TestCase):
             str(context_exc_setattr_dummy1_attr3.exception)
         )
 
-    def test_freeze_deep_object_not_inplace(self):
+    def test_freeze_deep_object_on_freeze_copy(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -410,7 +515,7 @@ class TestFreeze(unittest.TestCase):
             dummy3=Dummy(attr1=31, attr2=32, attr3=33)
         )
 
-        frozen_deep_dummy = freeze(deep_dummy, inplace=False)
+        frozen_deep_dummy = freeze(deep_dummy, on_freeze="copy")
 
         with self.assertRaises(FrozenException) as context_exc_dummy1:
             frozen_deep_dummy.dummy1 = 99
@@ -483,17 +588,17 @@ class TestFreeze(unittest.TestCase):
                 dummy_with_binary_file = DummyWithBinaryFile()
 
                 with self.assertRaises(io.UnsupportedOperation) as text_write_context:
-                    freeze(dummy_with_text_file, inplace=True)
+                    freeze(dummy_with_text_file, on_freeze="inplace")
 
                 with self.assertRaises(io.UnsupportedOperation) as binary_write_context:
-                    freeze(dummy_with_binary_file, inplace=True)
+                    freeze(dummy_with_binary_file, on_freeze="inplace")
 
         self.assertEqual("Text file handlers can't be frozen",
                          str(text_write_context.exception))
         self.assertEqual("Binary file handlers can't be frozen",
                          str(binary_write_context.exception))
 
-    def test_hash_inplace(self):
+    def test_hash_on_freeze_inplace(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -501,10 +606,10 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, inplace=True)
+        frozen_dummy = freeze(dummy, on_freeze="inplace")
         self.assertEqual(hash(dummy), hash(frozen_dummy))
 
-    def test_hash_not_inplace(self):
+    def test_hash_on_freeze_copy(self):
         class Dummy(object):
             def __init__(self, attr1: int, attr2: int, attr3: int):
                 self.attr1 = attr1
@@ -512,7 +617,7 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, inplace=False)
+        frozen_dummy = freeze(dummy, on_freeze="copy")
         self.assertNotEqual(hash(dummy), hash(frozen_dummy))
 
     def test_hash_frozen_object_as_key_in_dict(self):
@@ -523,8 +628,8 @@ class TestFreeze(unittest.TestCase):
                 self.__attr3 = attr3
 
         dummy = Dummy(attr1=1, attr2=2, attr3=3)
-        frozen_dummy = freeze(dummy, inplace=False)
-        frozen_dummy_inplace = freeze(dummy, inplace=True)
+        frozen_dummy = freeze(dummy, on_freeze="copy")
+        frozen_dummy_inplace = freeze(dummy, on_freeze="inplace")
         my_dict: Dict = {dummy: "this is a dummy object"}
 
         self.assertNotEqual(hash(dummy), hash(frozen_dummy))
@@ -537,8 +642,8 @@ class TestFreeze(unittest.TestCase):
             COUNTER = 1
 
         dummy = Dummy()
-        frozen_dummy = freeze(dummy, inplace=False)
-        frozen_dummy_inplace = freeze(dummy, inplace=True)
+        frozen_dummy = freeze(dummy, on_freeze="copy")
+        frozen_dummy_inplace = freeze(dummy, on_freeze="inplace")
         Dummy.COUNTER += 1
 
         self.assertEqual(2, Dummy.COUNTER)
@@ -677,9 +782,9 @@ class TestFreeze(unittest.TestCase):
         dummy1 = Dummy(1)
         dummy2 = Dummy(2)
         dummy3 = Dummy(3)
-        frozen_dummy1 = freeze(dummy1, inplace=False)
-        frozen_dummy2 = freeze(dummy2, inplace=False)
-        frozen_dummy3 = freeze(dummy3, inplace=False)
+        frozen_dummy1 = freeze(dummy1, on_freeze="copy")
+        frozen_dummy2 = freeze(dummy2, on_freeze="copy")
+        frozen_dummy3 = freeze(dummy3, on_freeze="copy")
 
         self.assertEqual(Dummy.__name__, frozen_dummy1.get_gelidum_hot_class_name())
         self.assertEqual(Dummy.__name__, frozen_dummy2.get_gelidum_hot_class_name())
@@ -695,9 +800,9 @@ class TestFreeze(unittest.TestCase):
         dummy1 = Dummy()
         dummy2 = Dummy()
         dummy3 = Dummy()
-        frozen_dummy1 = freeze(dummy1, inplace=False)
-        frozen_dummy2 = freeze(dummy2, inplace=False)
-        frozen_dummy3 = freeze(dummy3, inplace=False)
+        frozen_dummy1 = freeze(dummy1, on_freeze="copy")
+        frozen_dummy2 = freeze(dummy2, on_freeze="copy")
+        frozen_dummy3 = freeze(dummy3, on_freeze="copy")
 
         self.assertEqual(Dummy.__name__, frozen_dummy1.get_gelidum_hot_class_name())
         self.assertEqual(Dummy.__name__, frozen_dummy2.get_gelidum_hot_class_name())
@@ -718,9 +823,9 @@ class TestFreeze(unittest.TestCase):
         dummy1 = Dummy(1)
         dummy2 = Dummy(2)
         dummy3 = Dummy(3)
-        frozen_dummy1 = freeze(dummy1, inplace=False)
-        frozen_dummy2 = freeze(dummy2, inplace=False)
-        frozen_dummy3 = freeze(dummy3, inplace=False)
+        frozen_dummy1 = freeze(dummy1, on_freeze="copy")
+        frozen_dummy2 = freeze(dummy2, on_freeze="copy")
+        frozen_dummy3 = freeze(dummy3, on_freeze="copy")
 
         self.assertSetEqual({frozen_dummy1.__class__}, set(frozen_classes.values()))
         self.assertEqual(frozen_dummy1.__class__, frozen_dummy2.__class__, frozen_dummy3.__class__)

--- a/tests/gelidum_tests/test_freeze.py
+++ b/tests/gelidum_tests/test_freeze.py
@@ -244,8 +244,8 @@ class TestFreeze(unittest.TestCase):
                 frozen_object = copy.deepcopy(obj)
                 self.original_obj = obj
                 return frozen_object
-            # TODO: check type hint of frozen_obj
-            def on_update(self, frozen_obj: object,
+
+            def on_update(self, frozen_obj: Type["FrozenBase"],
                           message: str, *args, **kwargs):
                 self.log.warning(message)
                 with self.lock:
@@ -851,7 +851,7 @@ class TestFreeze(unittest.TestCase):
             str(context.exception)
         )
 
-    def test_invalid_valeu_for_on_freeze_parameter(self):
+    def test_invalid_value_for_on_freeze_parameter(self):
         with self.assertRaises(AttributeError) as context:
             freeze(("one", 2, "three"), on_freeze=99)
 

--- a/tests/gelidum_tests/test_freeze.py
+++ b/tests/gelidum_tests/test_freeze.py
@@ -276,6 +276,7 @@ class TestFreeze(unittest.TestCase):
             unittest.mock.call("Can't assign 'attr1' on immutable instance"),
             mock_logger.warning.call_args
         )
+        self.assertEqual(id(dummy), id(update_try_recorder.original_obj))
 
     def test_freeze_simple_object_on_freeze_inplace(self):
         class Dummy(object):

--- a/tests/test_time_performance.py
+++ b/tests/test_time_performance.py
@@ -29,11 +29,11 @@ class TestTimePerformance(unittest.TestCase):
 
         dummy1 = Dummy(attr="1")
         start_inplace = time.time()
-        freeze(dummy1, inplace=True)
+        freeze(dummy1, on_freeze="inplace")
         spent_time_inplace = time.time() - start_inplace
         dummy2 = Dummy(attr="1")
         start_not_inplace = time.time()
-        freeze(dummy2, inplace=False)
+        freeze(dummy2, on_freeze="copy")
         spent_time_not_inplace = time.time() - start_not_inplace
 
         self.assertLessEqual(spent_time_inplace, spent_time_not_inplace)
@@ -49,7 +49,7 @@ class TestTimePerformance(unittest.TestCase):
         spent_times = []
         for i in range(5):
             start = time.time()
-            freeze(dummy, inplace=False)
+            freeze(dummy, on_freeze="copy")
             spent_times.append(time.time() - start)
 
         spent_time = sum(spent_times) / len(spent_times)

--- a/tests/test_time_performance.py
+++ b/tests/test_time_performance.py
@@ -55,4 +55,3 @@ class TestTimePerformance(unittest.TestCase):
         spent_time = sum(spent_times) / len(spent_times)
 
         self.assertLessEqual(spent_time, 0.4)
-


### PR DESCRIPTION
- Replace inplace parameter by on_freeze.
- Include use case of on_freeze: Callable.