### PR TITLE
Python3.10

### DIFF
--- a/gelidum/tests/collection_tests/test_frozendict.py
+++ b/gelidum/tests/collection_tests/test_frozendict.py
@@ -1,5 +1,5 @@
 import unittest
-from collections import ValuesView, KeysView
+from collections.abc import ValuesView, KeysView
 from typing import Any
 
 from gelidum import FrozenException, freeze

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 python_interpreter = python_implementation()
-python_interpreter_version = tuple(int(number) for number in python_version_tuple())
+python_interpreter_version = tuple(int(number) for number in python_version_tuple()[:2])
 
 
 if (


### PR DESCRIPTION
Fix compatibility for 3.10 RC version

I think the `.abc` is available since python 3.3 so should cause no issues.