### PR TITLE
New module: on_freeze

### DIFF
--- a/gelidum/__init__.py
+++ b/gelidum/__init__.py
@@ -2,3 +2,4 @@ from gelidum.freeze import freeze  # noqa
 from gelidum.decorators import freeze_params, freeze_final  # noqa
 from gelidum.exceptions import FrozenException  # noqa
 from gelidum.typing import Final  # noqa
+from gelidum.on_freeze import OnFreezeIdentityFunc, OnFreezeCopier, OnFreezeOriginalObjTracker  # noqa

--- a/gelidum/on_freeze.py
+++ b/gelidum/on_freeze.py
@@ -1,0 +1,58 @@
+import copy
+from typing import Any, Optional, Union
+
+from gelidum.typing import OnFreezeFuncType
+
+
+class OnFreezeCopier:
+    def __call__(self, obj: Any) -> Any:
+        return copy.deepcopy(obj)
+
+
+class OnFreezeIdentityFunc:
+    def __call__(self, obj: Any) -> Any:
+        return obj
+
+
+class OnFreezeOriginalObjTracker(OnFreezeCopier):
+    """
+    A callable class that stores the first object that was
+    frozen. Useful for keeping track of original "hot" objects.
+    """
+    def __init__(self):
+        self.__original_obj: Optional[Any] = None
+
+    def __call__(self, obj: Any) -> Any:
+        if self.__original_obj is None:
+            self.__original_obj = obj
+        return super().__call__(obj=obj)
+
+    @property
+    def original_obj(self) -> Optional[Any]:
+        return self.__original_obj
+
+
+_ON_FREEZE_COPIER = OnFreezeCopier()
+_ON_FREEZE_IDENTITY_FUNC = OnFreezeIdentityFunc()
+
+
+def on_freeze_func_creator(on_freeze: Union[str, OnFreezeFuncType]) -> OnFreezeFuncType:
+    if isinstance(on_freeze, str):
+        if on_freeze == "copy":
+            return _ON_FREEZE_COPIER
+        elif on_freeze == "inplace":
+            return _ON_FREEZE_IDENTITY_FUNC
+        else:
+            raise AttributeError(
+                f"Invalid value for on_freeze parameter, '{on_freeze}' found, "
+                f"only 'copy' and 'inplace' are valid options if passed a string"
+            )
+
+    elif callable(on_freeze):
+        return on_freeze
+
+    else:
+        raise AttributeError(
+            f"Invalid value for on_freeze parameter, '{on_freeze}' found, "
+            f"only 'copy', 'inplace' or a callable are valid options"
+        )

--- a/gelidum/tests/gelidum_tests/test_freeze.py
+++ b/gelidum/tests/gelidum_tests/test_freeze.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 from gelidum import FrozenException
 from gelidum import freeze
 from gelidum.collections import frozendict, frozenlist, frozenzet
-from gelidum.frozen import FrozenBase, clear_frozen_classes
 from gelidum.frozen import FrozenBase, get_frozen_classes, clear_frozen_classes
 
 
@@ -99,7 +98,7 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual("three", frozen_list[2])
         self.assertEqual(1, len(caught_warnings))
         self.assertEqual(
-            "Use of inplace is deprecated and will be removed in next major version (0.5.0)",
+            "Use of inplace is deprecated and will be removed in next major version (0.6.0)",
             str(caught_warnings[0].message)
         )
 
@@ -180,7 +179,7 @@ class TestFreeze(unittest.TestCase):
         self.assertEqual(id(dummy), id(frozen_dummy))
         self.assertEqual(1, len(caught_warnings))
         self.assertEqual(
-            "Use of inplace is deprecated and will be removed in next major version (0.5.0)",
+            "Use of inplace is deprecated and will be removed in next major version (0.6.0)",
             str(caught_warnings[0].message)
         )
 
@@ -198,7 +197,7 @@ class TestFreeze(unittest.TestCase):
         self.assertNotEqual(id(dummy), id(frozen_dummy))
         self.assertEqual(1, len(caught_warnings))
         self.assertEqual(
-            "Use of inplace is deprecated and will be removed in next major version (0.5.0)",
+            "Use of inplace is deprecated and will be removed in next major version (0.6.0)",
             str(caught_warnings[0].message)
         )
 
@@ -1019,7 +1018,7 @@ class TestFreeze(unittest.TestCase):
 
         self.assertEqual(
             "Invalid value for on_freeze parameter, '99' found, "
-            "only 'copy', 'inplace' or a function are valid options",
+            "only 'copy', 'inplace' or a callable are valid options",
             str(context.exception)
         )
 

--- a/gelidum/tests/gelidum_tests/test_on_freeze.py
+++ b/gelidum/tests/gelidum_tests/test_on_freeze.py
@@ -1,0 +1,161 @@
+import logging
+import unittest
+from unittest import mock
+from typing import List, Any
+from unittest.mock import call
+
+from gelidum import OnFreezeCopier, OnFreezeOriginalObjTracker, OnFreezeIdentityFunc
+from gelidum import freeze
+from gelidum.frozen import FrozenBase, clear_frozen_classes
+
+
+class TestOnFreeze(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_frozen_classes()
+
+    def test_on_freeze_original_obj_tracking(self):
+        class DummyAttr1(object):
+            def __init__(self, value: int):
+                self.attr = value
+
+        class DummyAttr2(object):
+            def __init__(self, value: int):
+                self.attr = value
+
+        class Dummy(object):
+            def __init__(self, value1: int, value2: int):
+                self.attr1 = DummyAttr1(value1)
+                self.attr2 = DummyAttr2(value2)
+
+        dummy1 = Dummy(value1=1, value2=2)
+
+        freezer = OnFreezeOriginalObjTracker()
+
+        frozen_dummy1 = freeze(dummy1, on_freeze=freezer)
+        original_obj = freezer.original_obj
+
+        self.assertEqual(id(dummy1), id(original_obj))
+        self.assertNotEqual(id(dummy1), id(frozen_dummy1))
+        self.assertTrue(isinstance(original_obj, Dummy))
+        self.assertTrue(isinstance(original_obj.attr1, DummyAttr1))
+        self.assertTrue(isinstance(original_obj.attr2, DummyAttr2))
+        self.assertIs(original_obj.__class__, Dummy)
+        self.assertIs(original_obj.attr1.__class__, DummyAttr1)
+        self.assertIs(original_obj.attr2.__class__, DummyAttr2)
+        self.assertEqual(1, original_obj.attr1.attr)
+        self.assertEqual(2, original_obj.attr2.attr)
+        self.assertTrue(isinstance(frozen_dummy1, Dummy))
+        self.assertTrue(isinstance(frozen_dummy1.attr1, DummyAttr1))
+        self.assertTrue(isinstance(frozen_dummy1.attr2, DummyAttr2))
+        self.assertTrue(isinstance(frozen_dummy1, FrozenBase))
+        self.assertTrue(isinstance(frozen_dummy1.attr1, FrozenBase))
+        self.assertTrue(isinstance(frozen_dummy1.attr2, FrozenBase))
+        self.assertIsNot(frozen_dummy1.__class__, Dummy)
+        self.assertIsNot(frozen_dummy1.attr1.__class__, DummyAttr1)
+        self.assertIsNot(frozen_dummy1.attr2.__class__, DummyAttr2)
+        self.assertEqual(1, frozen_dummy1.attr1.attr)
+        self.assertEqual(2, frozen_dummy1.attr2.attr)
+
+    def test_on_freeze_logging(self):
+        class DummyAttr1(object):
+            def __init__(self, value: int):
+                self.attr = value
+
+        class DummyAttr2(object):
+            def __init__(self, value: int):
+                self.attr = value
+
+        class Dummy(object):
+            def __init__(self, value1: int, value2: int):
+                self.attr1 = DummyAttr1(value1)
+                self.attr2 = DummyAttr2(value2)
+
+        dummy1 = Dummy(value1=1, value2=2)
+
+        class OnFreezeLogger(OnFreezeCopier):
+            def __init__(self, log: logging.Logger):
+                self.__log = log
+
+            def __call__(self, obj: Any) -> Any:
+                self.__log.debug(f"{obj.__class__.__name__} object frozen")
+                return super().__call__(obj=obj)
+
+        mock_log = mock.Mock()
+        freezer = OnFreezeLogger(log=mock_log)
+
+        frozen_dummy1 = freeze(dummy1, on_freeze=freezer)
+
+        self.assertEqual(
+            [call('Dummy object frozen'),
+             call('DummyAttr1 object frozen'),
+             call('DummyAttr2 object frozen')],
+            mock_log.debug.call_args_list
+        )
+        self.assertTrue(isinstance(frozen_dummy1, Dummy))
+        self.assertTrue(isinstance(frozen_dummy1.attr1, DummyAttr1))
+        self.assertTrue(isinstance(frozen_dummy1.attr2, DummyAttr2))
+        self.assertTrue(isinstance(frozen_dummy1, FrozenBase))
+        self.assertTrue(isinstance(frozen_dummy1.attr1, FrozenBase))
+        self.assertTrue(isinstance(frozen_dummy1.attr2, FrozenBase))
+        self.assertIsNot(frozen_dummy1.__class__, Dummy)
+        self.assertIsNot(frozen_dummy1.attr1.__class__, DummyAttr1)
+        self.assertIsNot(frozen_dummy1.attr2.__class__, DummyAttr2)
+        self.assertEqual(1, frozen_dummy1.attr1.attr)
+        self.assertEqual(2, frozen_dummy1.attr2.attr)
+
+    def test_on_freeze_custom_freezer_in_place(self):
+        class DummyAttr1(object):
+            def __init__(self, value: int):
+                self.attr = value
+
+        class DummyAttr2(object):
+            def __init__(self, value: int):
+                self.attr = value
+
+        class Dummy(object):
+            def __init__(self, value1: int, value2: int):
+                self.attr1 = DummyAttr1(value1)
+                self.attr2 = DummyAttr2(value2)
+
+        dummy1 = Dummy(value1=1, value2=2)
+
+        class OnFreezeFullTrackingInPlace(OnFreezeIdentityFunc):
+            def __init__(self):
+                self.__objs: List[Any] = []
+
+            def __call__(self, obj: Any) -> Any:
+                self.__objs.append(obj)
+                return super().__call__(obj=obj)
+
+            @property
+            def original_objs(self) -> List[Any]:
+                return self.__objs
+
+        freezer = OnFreezeFullTrackingInPlace()
+
+        frozen_dummy1 = freeze(dummy1, on_freeze=freezer)
+        original_objs = freezer.original_objs
+
+        self.assertEqual(3, len(original_objs))
+        self.assertEqual(id(dummy1), id(original_objs[0]))
+        self.assertEqual(id(dummy1.attr1), id(original_objs[1]))
+        self.assertEqual(id(dummy1.attr2), id(original_objs[2]))
+        self.assertEqual(id(original_objs[0].attr1), id(original_objs[1]))
+        self.assertEqual(id(original_objs[0].attr2), id(original_objs[2]))
+        self.assertEqual(id(dummy1), id(frozen_dummy1))
+        self.assertTrue(isinstance(original_objs[0], Dummy))
+        self.assertTrue(isinstance(original_objs[1], DummyAttr1))
+        self.assertTrue(isinstance(original_objs[2], DummyAttr2))
+        self.assertEqual(1, original_objs[1].attr)
+        self.assertEqual(2, original_objs[2].attr)
+        self.assertTrue(isinstance(frozen_dummy1, Dummy))
+        self.assertTrue(isinstance(frozen_dummy1.attr1, DummyAttr1))
+        self.assertTrue(isinstance(frozen_dummy1.attr2, DummyAttr2))
+        self.assertTrue(isinstance(frozen_dummy1, FrozenBase))
+        self.assertTrue(isinstance(frozen_dummy1.attr1, FrozenBase))
+        self.assertTrue(isinstance(frozen_dummy1.attr2, FrozenBase))
+        self.assertIsNot(frozen_dummy1.__class__, Dummy)
+        self.assertIsNot(frozen_dummy1.attr1.__class__, DummyAttr1)
+        self.assertIsNot(frozen_dummy1.attr2.__class__, DummyAttr2)
+        self.assertEqual(1, frozen_dummy1.attr1.attr)
+        self.assertEqual(2, frozen_dummy1.attr2.attr)


### PR DESCRIPTION
This PR includes adds more fine-grained control of the freezing process. To be more precise, to the **on_freeze** function. There are two main on_freeze posibilities: deep-copy and inplace (pass the reference directly). There was another option: passing a callable. This PR adds some basing callable classes to allow tracking what objects are going to be frozen.

By creating a OnFreezeOriginalObjTracker object, it is possible to store a reference to the original object before being frozen.

The following test test_on_freeze_original_obj_tracking is a good example of this use-case:

```python
import logging
import unittest
from unittest import mock
from typing import List, Any
from unittest.mock import call
from gelidum import OnFreezeCopier, OnFreezeOriginalObjTracker, OnFreezeIdentityFunc
from gelidum import freeze
from gelidum.frozen import FrozenBase, clear_frozen_classes


class TestOnFreeze(unittest.TestCase):

    def setUp(self) -> None:
        clear_frozen_classes()

    def test_on_freeze_original_obj_tracking(self):
        class DummyAttr1(object):
            def __init__(self, value: int):
                self.attr = value

        class DummyAttr2(object):
            def __init__(self, value: int):
                self.attr = value

        class Dummy(object):
            def __init__(self, value1: int, value2: int):
                self.attr1 = DummyAttr1(value1)
                self.attr2 = DummyAttr2(value2)

        dummy1 = Dummy(value1=1, value2=2)

        freezer = OnFreezeOriginalObjTracker()

        frozen_dummy1 = freeze(dummy1, on_freeze=freezer)
        original_obj = freezer.original_obj

        self.assertEqual(id(dummy1), id(original_obj))
        self.assertNotEqual(id(dummy1), id(frozen_dummy1))
```