### PR TITLE
Fix frozendict __init__ method

### DIFF
--- a/gelidum/collections/frozendict.py
+++ b/gelidum/collections/frozendict.py
@@ -16,7 +16,8 @@ class frozendict(dict, FrozenBase): # noqa
 
     def __init__(
             self,
-            mapping: Optional[Union[Mapping, Tuple[Hashable, Any]]] = None, /,
+            mapping: Optional[Union[Mapping, Tuple[Hashable, Any]]] = None,
+            /,  # noqa
             freeze_func: Optional[Callable[[Any], FrozenBase]] = None,
             **kwargs
     ):

--- a/gelidum/collections/frozendict.py
+++ b/gelidum/collections/frozendict.py
@@ -17,7 +17,6 @@ class frozendict(dict, FrozenBase): # noqa
     def __init__(
             self,
             mapping: Optional[Union[Mapping, Tuple[Hashable, Any]]] = None,
-            /,  # noqa
             freeze_func: Optional[Callable[[Any], FrozenBase]] = None,
             **kwargs
     ):

--- a/gelidum/collections/frozendict.py
+++ b/gelidum/collections/frozendict.py
@@ -16,8 +16,7 @@ class frozendict(dict, FrozenBase): # noqa
 
     def __init__(
             self,
-            mapping: Optional[Union[Mapping, Tuple[Hashable, Any]]] = None,
-            /,
+            mapping: Optional[Union[Mapping, Tuple[Hashable, Any]]] = None, /,
             freeze_func: Optional[Callable[[Any], FrozenBase]] = None,
             **kwargs
     ):

--- a/gelidum/collections/frozendict.py
+++ b/gelidum/collections/frozendict.py
@@ -1,5 +1,9 @@
-from collections import Mapping
 from typing import Any, Callable, Optional, Union, Tuple, Hashable
+try:
+    from collections import Mapping
+except ImportError:
+    # For python > 3.10
+    from collections.abc import Mapping
 
 from gelidum.exceptions import FrozenException
 from gelidum.frozen import FrozenBase

--- a/gelidum/tests/collection_tests/test_frozendict.py
+++ b/gelidum/tests/collection_tests/test_frozendict.py
@@ -13,7 +13,7 @@ class TestFrozendict(unittest.TestCase):  # noqa
 
         self.assertEqual(0, len(frozen_list))
 
-    def test_construction(self):
+    def test_construction_from_dict(self):
         class Dummy:
             def __init__(self, value: Any):
                 self.value = value
@@ -26,6 +26,12 @@ class TestFrozendict(unittest.TestCase):  # noqa
         self.assertEqual("2", frozen_dict["two"])
         self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
         self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_from_empty_dict(self):
+        frozen_dict = frozendict({})
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(0, len(frozen_dict))
 
     def test_construction_from_generator(self):
         class Dummy:
@@ -52,6 +58,91 @@ class TestFrozendict(unittest.TestCase):  # noqa
                 self.value = value
 
         frozen_dict = frozendict(one=1, two="2", three=Dummy(3))
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(3, len(frozen_dict))
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_from_dict_and_kwargs(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        frozen_dict = frozendict(
+            {"k0": "v0", "k1": "v1"},
+            one=1, two="2", three=Dummy(3)
+        )
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(5, len(frozen_dict))
+        self.assertEqual("v0", frozen_dict["k0"])
+        self.assertEqual("v1", frozen_dict["k1"])
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_empty_dict_and_kwargs(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        frozen_dict = frozendict({}, one=1, two="2", three=Dummy(3))
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(3, len(frozen_dict))
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_from_list_of_pairs_and_kwargs(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        frozen_dict = frozendict(
+            [("k0", "v0"), ("k1", "v1")],
+            one=1, two="2", three=Dummy(3)
+        )
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(5, len(frozen_dict))
+        self.assertEqual("v0", frozen_dict["k0"])
+        self.assertEqual("v1", frozen_dict["k1"])
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_list_of_strings_and_kwargs(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        frozen_dict = frozendict(
+            ["k0", "v0", "k1", "v1"],
+            one=1, two="2", three=Dummy(3)
+        )
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(5, len(frozen_dict))
+        self.assertEqual("1", frozen_dict["k"])
+        self.assertEqual("1", frozen_dict["v"])
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_empty_list_and_kwargs(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        frozen_dict = frozendict([], one=1, two="2", three=Dummy(3))
 
         self.assertTrue(isinstance(frozen_dict, FrozenBase))
         self.assertEqual(3, len(frozen_dict))

--- a/gelidum/tests/collection_tests/test_frozendict.py
+++ b/gelidum/tests/collection_tests/test_frozendict.py
@@ -1,6 +1,6 @@
 import unittest
 from collections.abc import ValuesView, KeysView
-from typing import Any
+from typing import Any, Tuple
 
 from gelidum import FrozenException, freeze
 from gelidum.collections.frozendict import frozendict
@@ -19,6 +19,39 @@ class TestFrozendict(unittest.TestCase):  # noqa
                 self.value = value
 
         frozen_dict = frozendict({"one": 1, "two": "2", "three": Dummy(3)})
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(3, len(frozen_dict))
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_from_generator(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        def test_generator() -> Tuple[str, int]:
+            yield "one", 1
+            yield "two", "2"
+            yield "three", Dummy(3)
+
+        frozen_dict = frozendict(test_generator())
+
+        self.assertTrue(isinstance(frozen_dict, FrozenBase))
+        self.assertEqual(3, len(frozen_dict))
+        self.assertEqual(1, frozen_dict["one"])
+        self.assertEqual("2", frozen_dict["two"])
+        self.assertTrue(isinstance(frozen_dict["three"], FrozenBase))
+        self.assertEqual(3, frozen_dict["three"].value)
+
+    def test_construction_from_kwargs(self):
+        class Dummy:
+            def __init__(self, value: Any):
+                self.value = value
+
+        frozen_dict = frozendict(one=1, two="2", three=Dummy(3))
 
         self.assertTrue(isinstance(frozen_dict, FrozenBase))
         self.assertEqual(3, len(frozen_dict))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = open(os.path.join(root_dir_path, "README.md")).read()
 
 setup(
     name="gelidum",
-    version="0.5.7",
+    version="0.5.8",
     author="Diego J. Romero López",
     author_email="diegojromerolopez@gmail.com",
     description="Freeze your python objects",


### PR DESCRIPTION
Allow creation of frozendict by passing a generator or kwargs.

Requested and devised by nolsto in https://github.com/diegojromerolopez/gelidum/issues/28.