### PR TITLE
Fix the type hints

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v2
@@ -16,13 +16,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black flake8 isort coverage
+          pip install uv
+          uv sync --all-groups
       - name: black
         run: |
-          black --check gelidum
+          uv run black --check gelidum
       - name: flake8
         run: |
-          flake8 gelidum
+          uv run flake8 gelidum
       - name: isort
         run: |
-          isort --check-only gelidum
+          uv run isort --check-only gelidum
+      - name: mypy
+        run: |
+         uv run mypy gelidum

--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.9', 'pypy-3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# uv
+uv.lock
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.10.0 (2025-11-23)
+### Features
+- Remove support from Python 3.7.
+- Remove support from Python 3.8.
+### Fixes
+- Fixes type hints.
+
 ## 0.9.1 (2025-08-17)
 ### Fixes
 - Fix pyproject.toml file.

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The following versions are deprecated and will be removed in the following dates
 | Python version | Support removal date |
 |:--------------:|:--------------------:|
 |      3.7       |      2025-06-01      |
-|      3.8       |      2026-01-01      |
+|      3.8       |      2025-11-01      |
 |      3.9       |      2026-06-01      |
 
 ## Roadmap

--- a/gelidum/__init__.py
+++ b/gelidum/__init__.py
@@ -8,4 +8,4 @@ from gelidum.on_freeze import (  # noqa
     OnFreezeIdentityFunc,
     OnFreezeOriginalObjTracker,
 )
-from gelidum.typing import Freezable  # noqa
+from gelidum.typing import Freezable, Frozen  # noqa

--- a/gelidum/collections/frozendict.py
+++ b/gelidum/collections/frozendict.py
@@ -1,14 +1,9 @@
-from typing import Any, Callable, Hashable, Optional, Sequence, Tuple, Union
-
-try:
-    from collections import Mapping
-except ImportError:
-    # For python > 3.10
-    from collections.abc import Mapping
+from collections.abc import Mapping
+from typing import Any, Callable, Dict, Hashable, Optional, Sequence, Tuple, Union
 
 from gelidum.exceptions import FrozenException
 from gelidum.frozen import FrozenBase
-from gelidum.typing import FrozenDict, FrozenType
+from gelidum.typing import FrozenDict
 
 __all__ = ['frozendict']
 
@@ -20,30 +15,34 @@ class frozendict(dict, FrozenBase):  # noqa
     def __init__(
         self,
         seq: Optional[Union[Mapping, Sequence, Tuple[Hashable, Any]]] = None,
-        freeze_func: Optional[Callable[[Any], FrozenBase]] = None,
+        freeze_func: Optional[Callable[[Any], Any]] = None,
         **kwargs,
     ):
         if freeze_func is None:
+            from gelidum.freeze import freeze
 
-            def freeze_func(item: Any) -> FrozenType:
-                from gelidum.freeze import freeze
-
+            def _freeze_func(item: Any) -> Any:
                 return freeze(item, on_update='exception', on_freeze='copy')
 
-        if seq is not None:
-            items = None
-            if isinstance(seq, Mapping):
-                items = seq.items()
-            elif isinstance(seq, Sequence):
-                items = seq
+            freeze_func = _freeze_func
 
-            if items is not None:
+        if seq is not None:
+            if isinstance(seq, Mapping):
                 super().__init__(
-                    {key: freeze_func(value) for key, value in items},
+                    {key: freeze_func(value) for key, value in seq.items()},
+                    **{key: freeze_func(value) for key, value in kwargs.items()},
+                )
+            elif isinstance(seq, Sequence):
+                super().__init__(
+                    {key: freeze_func(value) for key, value in seq},  # type: ignore[misc]
                     **{key: freeze_func(value) for key, value in kwargs.items()},
                 )
             else:
-                super().__init__({key: freeze_func(value) for key, value in seq})
+                # Assume it's an iterable of key-value pairs
+                super().__init__(
+                    {key: freeze_func(value) for key, value in seq},  # type: ignore[misc]
+                    **{key: freeze_func(value) for key, value in kwargs.items()},
+                )
         elif kwargs:
             super().__init__({key: freeze_func(value) for key, value in kwargs.items()})
         else:
@@ -61,7 +60,7 @@ class frozendict(dict, FrozenBase):  # noqa
     def get_gelidum_hot_class_module(cls) -> str:
         return 'builtins.dict'
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # type: ignore[override]
         return hash(tuple((k, v) for k, v in self.items()))
 
     def __getitem__(self, key) -> Any:
@@ -72,21 +71,23 @@ class frozendict(dict, FrozenBase):  # noqa
         except IndexError:
             raise IndexError('frozendict index out of range')
 
-    def __add__(self, other: FrozenDict) -> FrozenDict:
+    def __add__(self, other: 'FrozenDict') -> 'frozendict':  # type: ignore[valid-type]
         joined_dict = self | other
         return frozendict(joined_dict)
 
-    def __or__(self, other: FrozenDict) -> FrozenDict:
-        if hasattr(super, '__or__'):
-            return super().__or__(other)
+    def __or__(self, other: FrozenDict) -> 'frozendict':  # type: ignore[override,valid-type]
+        if hasattr(dict, '__or__'):
+            joined: Dict[Any, Any] = dict.__or__(self, other)  # type: ignore[arg-type,operator]
+            return frozendict(joined)
         # Python version < 3.9
-        result_dict = dict()
+        result_dict: Dict[Any, Any] = dict()
         result_dict.update(self)
-        result_dict.update(other)
+        result_dict.update(other)  # type: ignore[arg-type]
         return frozendict(result_dict)
 
-    def __sub__(self, other: FrozenDict) -> FrozenDict:
-        return frozendict({k: v for k, v in self.items() if k not in other})
+    def __sub__(self, other: FrozenDict) -> 'frozendict':  # type: ignore[valid-type]
+        result = {k: v for k, v in self.items() if k not in other}  # type: ignore[attr-defined]
+        return frozendict(result)  # type: ignore[arg-type,operator]
 
     def remove(self, x):
         self.__raise_immutable_exception()

--- a/gelidum/collections/frozenlist.py
+++ b/gelidum/collections/frozenlist.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Generator, Optional, Sequence, Union
 
 from gelidum.exceptions import FrozenException
 from gelidum.frozen import FrozenBase
-from gelidum.typing import FrozenList, FrozenType
+from gelidum.typing import FrozenList
 
 __all__ = ['frozenlist']
 
@@ -15,14 +15,15 @@ class frozenlist(tuple, FrozenBase):  # noqa
         raise FrozenException("'frozenlist' object is immutable")
 
     def __new__(
-        cls, seq: Optional[_FrozenListParameterType] = None, freeze_func: Optional[Callable[[Any], FrozenBase]] = None
+        cls, seq: Optional[_FrozenListParameterType] = None, freeze_func: Optional[Callable[[Any], Any]] = None
     ) -> 'frozenlist':
         if freeze_func is None:
+            from gelidum.freeze import freeze
 
-            def freeze_func(item: Any) -> FrozenType:
-                from gelidum.freeze import freeze
-
+            def _freeze_func(item: Any) -> Any:
                 return freeze(item, on_update='exception', on_freeze='copy')
+
+            freeze_func = _freeze_func
 
         if seq:
             self = tuple.__new__(cls, (freeze_func(arg) for arg in seq))
@@ -31,7 +32,7 @@ class frozenlist(tuple, FrozenBase):  # noqa
         return self
 
     def __init__(
-        self, seq: Optional[_FrozenListParameterType] = None, freeze_func: Optional[Callable[[Any], FrozenBase]] = None
+        self, seq: Optional[_FrozenListParameterType] = None, freeze_func: Optional[Callable[[Any], Any]] = None
     ):
         pass
 
@@ -55,15 +56,15 @@ class frozenlist(tuple, FrozenBase):  # noqa
         except IndexError:
             raise IndexError('frozenlist index out of range')
 
-    def __add__(self, other: FrozenList) -> FrozenList:
+    def __add__(self, other: FrozenList) -> 'frozenlist':  # type: ignore[override,valid-type]
         joined_list = []
         for item in self:
             joined_list.append(item)
-        for item in other:
+        for item in other:  # type: ignore[union-attr,attr-defined]
             joined_list.append(item)
         return frozenlist(joined_list)
 
-    def __mul__(self, times: int) -> FrozenList:
+    def __mul__(self, times: int) -> 'frozenlist':  # type: ignore[override]
         as_list = []
         for item in self:
             as_list.append(item)

--- a/gelidum/collections/frozenndarray.py
+++ b/gelidum/collections/frozenndarray.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Optional
 
-import numpy as np
+import numpy as np  # type: ignore[import-not-found]
 
 from gelidum.exceptions import FrozenException
 from gelidum.frozen import FrozenBase
@@ -14,7 +14,7 @@ class frozenndarray(np.ndarray, FrozenBase):  # noqa
     information about numpy.ndarray subclassing.
     """
 
-    def __new__(cls, ndarray: np.ndarray, freeze_func: Optional[Callable[[Any], FrozenBase]] = None, *args, **kwargs):
+    def __new__(cls, ndarray: np.ndarray, freeze_func: Optional[Callable[[Any], Any]] = None, *args, **kwargs):
         obj = ndarray.copy().view(cls)
         obj.flags.writeable = False
         return obj

--- a/gelidum/collections/frozenzet.py
+++ b/gelidum/collections/frozenzet.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Union
 
 from gelidum.exceptions import FrozenException
 from gelidum.frozen import FrozenBase
-from gelidum.typing import FrozenType, FrozenZet
+from gelidum.typing import FrozenZet
 
 __all__ = ['frozenzet']
 
@@ -14,14 +14,15 @@ class frozenzet(frozenset, FrozenBase):  # noqa
         raise FrozenException("'frozenzet' object is immutable")
 
     def __new__(
-        cls, seq: Optional[_FrozenZetParameterType] = None, freeze_func: Optional[Callable[[Any], FrozenBase]] = None
+        cls, seq: Optional[_FrozenZetParameterType] = None, freeze_func: Optional[Callable[[Any], Any]] = None
     ) -> 'frozenzet':
         if freeze_func is None:
+            from gelidum.freeze import freeze
 
-            def freeze_func(item: Any) -> FrozenType:
-                from gelidum.freeze import freeze
-
+            def _freeze_func(item: Any) -> Any:
                 return freeze(item, on_update='exception', on_freeze='copy')
+
+            freeze_func = _freeze_func
 
         if seq:
             self = frozenset.__new__(cls, (freeze_func(arg) for arg in seq))
@@ -30,7 +31,7 @@ class frozenzet(frozenset, FrozenBase):  # noqa
         return self
 
     def __init__(
-        self, seq: Optional[_FrozenZetParameterType] = None, freeze_func: Optional[Callable[[Any], FrozenBase]] = None
+        self, seq: Optional[_FrozenZetParameterType] = None, freeze_func: Optional[Callable[[Any], Any]] = None
     ):
         super().__init__()
 
@@ -49,11 +50,11 @@ class frozenzet(frozenset, FrozenBase):  # noqa
     def __hash__(self) -> int:
         return hash(tuple(v for v in self))
 
-    def __add__(self, other: FrozenZet) -> FrozenZet:
+    def __add__(self, other: FrozenZet) -> 'frozenzet':  # type: ignore[override,valid-type]
         joined_set = set()
         for item in self:
             joined_set.add(item)
-        for item in other:
+        for item in other:  # type: ignore[union-attr,attr-defined]
             joined_set.add(item)
         return frozenzet(joined_set)
 
@@ -75,25 +76,25 @@ class frozenzet(frozenset, FrozenBase):  # noqa
     def update(self, *others) -> None:
         self.__raise_immutable_exception()
 
-    def __ior__(self, *others) -> None:
+    def __ior__(self, *others) -> None:  # type: ignore[override,misc]
         self.__raise_immutable_exception()
 
     def intersection_update(self, *others) -> None:
         self.__raise_immutable_exception()
 
-    def __iand__(self, *others) -> None:
+    def __iand__(self, *others) -> None:  # type: ignore[override,misc]
         self.__raise_immutable_exception()
 
     def difference_update(self, *others) -> None:
         self.__raise_immutable_exception()
 
-    def __isub__(self, *others) -> None:
+    def __isub__(self, *others) -> None:  # type: ignore[override,misc]
         self.__raise_immutable_exception()
 
     def symmetric_difference_update(self, others) -> None:
         self.__raise_immutable_exception()
 
-    def __ixor__(self, *others) -> None:
+    def __ixor__(self, *others) -> None:  # type: ignore[override,misc]
         self.__raise_immutable_exception()
 
     def copy(self) -> 'frozenzet':

--- a/gelidum/decorators.py
+++ b/gelidum/decorators.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Iterable, Optional, Set
+from typing import Any, Callable, Iterable, Optional, Set
 
 from gelidum.freeze import freeze
 
 
-def freeze_params(params: Optional[Iterable[str]] = None):
-    def inner_freeze_params(func):
+def freeze_params(params: Optional[Iterable[str]] = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def inner_freeze_params(func: Callable[..., Any]) -> Callable[..., Any]:
         """Freeze all input params of a method"""
 
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             func_args = tuple([freeze(arg, on_freeze='copy') for arg in args])
             func_kwargs = {
-                kwarg_name: freeze(kwarg, on_freeze='copy') if kwarg_name in params else kwarg
+                kwarg_name: freeze(kwarg, on_freeze='copy') if params and kwarg_name in params else kwarg
                 for kwarg_name, kwarg in kwargs.items()
             }
             return func(*func_args, **func_kwargs)
@@ -24,11 +24,11 @@ def freeze_params(params: Optional[Iterable[str]] = None):
     return inner_freeze_params
 
 
-def freeze_freezable(func):
+def freeze_freezable(func: Callable[..., Any]) -> Callable[..., Any]:
     """Freeze all freezable params of a method"""
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         unnamed_params_to_freeze: Set[int] = {
             i
             for i, (param_name, param_typing) in enumerate(func.__annotations__.items())

--- a/gelidum/freeze.py
+++ b/gelidum/freeze.py
@@ -1,20 +1,23 @@
+from __future__ import annotations
+
 import io
 import sys
 import warnings
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from gelidum.collections import frozendict, frozenlist, frozenzet
 from gelidum.dependencies import NUMPY_INSTALLED
 from gelidum.exceptions import FrozenException
 from gelidum.frozen import FrozenBase, isfrozen, make_frozen_class
 from gelidum.frozen.frozen_class_creator import make_unique_class
 from gelidum.on_freeze import OnFreezeCopier, on_freeze_func_creator
-from gelidum.typing import FrozenList, FrozenType, OnFreezeFuncType, OnUpdateFuncType, T
+from gelidum.typing import Frozen, OnFreezeFuncType, OnUpdateFuncType, T
 from gelidum.utils import isbuiltin
 
-if NUMPY_INSTALLED:
-    from gelidum.collections import frozenndarray
+if TYPE_CHECKING:
+    from gelidum.collections.frozendict import frozendict
+    from gelidum.collections.frozenlist import frozenlist
+    from gelidum.collections.frozenzet import frozenzet
 
 NpArrayType = Any
 
@@ -25,7 +28,7 @@ def freeze(
     on_freeze: Union[str, OnFreezeFuncType] = 'copy',
     save_original_on_copy: bool = False,
     inplace: Optional[bool] = None,
-) -> FrozenType:
+) -> Frozen[T]:
 
     # inplace argument will be removed from freeze in the next major version (0.6.0)
     if isinstance(inplace, bool):
@@ -42,9 +45,9 @@ def freeze(
         if hasattr(obj.__class__, '__slots__') and on_freeze == 'inplace':
             raise FrozenException('Objects of classes with __slots__ cannot be frozen inplace')
 
-        on_freeze_func: OnFreezeFuncType = on_freeze_func_creator(on_freeze=on_freeze)
+        on_freeze_func = on_freeze_func_creator(on_freeze=on_freeze)
 
-    on_update_func: OnUpdateFuncType = __on_update_func(on_update=on_update)
+    on_update_func = __on_update_func(on_update=on_update)  # type: ignore[arg-type]
 
     return __freeze(
         obj=obj, on_update=on_update_func, on_freeze=on_freeze_func, save_original_on_copy=save_original_on_copy
@@ -72,7 +75,7 @@ def __freeze(
         return freeze_func(obj, on_update=on_update, on_freeze=on_freeze)
 
     if NUMPY_INSTALLED:
-        import numpy as np
+        import numpy as np  # type: ignore[import-not-found]
 
         if isinstance(obj, np.ndarray):
             return __freeze_ndarray(obj, on_update=on_update, on_freeze=on_freeze)
@@ -90,22 +93,28 @@ def __freeze_bytearray(obj: bytearray, *args, **kwargs) -> bytes:  # noqa
     return bytes(obj)
 
 
-def __freeze_ndarray(obj: NpArrayType, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> FrozenList:
-    def freeze_func(item: Any) -> FrozenType:
+def __freeze_ndarray(obj: NpArrayType, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> Any:
+    from gelidum.collections.frozenndarray import frozenndarray
+
+    def freeze_func(item: Any) -> Any:
         return freeze(item, on_update=on_update, on_freeze=on_freeze)
 
     return frozenndarray(obj, freeze_func=freeze_func)
 
 
-def __freeze_dict(obj: Dict, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> frozendict:
-    def freeze_func(item: Any) -> FrozenType:
+def __freeze_dict(obj: Dict, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> 'frozendict':
+    from gelidum.collections.frozendict import frozendict
+
+    def freeze_func(item: Any) -> Any:
         return freeze(item, on_update=on_update, on_freeze=on_freeze)
 
     return frozendict(obj, freeze_func=freeze_func)
 
 
-def __freeze_list(obj: List, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> FrozenList:
-    def freeze_func(item: Any) -> FrozenType:
+def __freeze_list(obj: List, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> 'frozenlist':
+    from gelidum.collections.frozenlist import frozenlist
+
+    def freeze_func(item: Any) -> Any:
         return freeze(item, on_update=on_update, on_freeze=on_freeze)
 
     return frozenlist(obj, freeze_func=freeze_func)
@@ -115,8 +124,10 @@ def __freeze_tuple(obj: Tuple, on_update: OnUpdateFuncType, on_freeze: OnFreezeF
     return tuple(freeze(item, on_update=on_update, on_freeze=on_freeze) for item in obj)
 
 
-def __freeze_set(obj: Set, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> frozenzet:
-    def freeze_func(item: Any) -> FrozenType:
+def __freeze_set(obj: Set, on_update: OnUpdateFuncType, on_freeze: OnFreezeFuncType) -> 'frozenzet':
+    from gelidum.collections.frozenzet import frozenzet
+
+    def freeze_func(item: Any) -> Any:
         return freeze(item, on_update=on_update, on_freeze=on_freeze)
 
     return frozenzet(obj, freeze_func=freeze_func)
@@ -154,11 +165,13 @@ def __freeze_object(
     # are the object attributes that we want to freeze
     if hasattr(obj.__class__, '__slots__'):
         attrs = tuple(obj.__class__.__slots__)
-        on_freeze: OnFreezeFuncType = on_freeze_func_creator(on_freeze='copy')
+        on_freeze_func_copy = on_freeze_func_creator(on_freeze='copy')
         frozen_class = make_unique_class(
             klass=obj.__class__,
             attrs={
-                attr: freeze(getattr(obj, attr), on_update=on_update, on_freeze=on_freeze, save_original_on_copy=False)
+                attr: freeze(
+                    getattr(obj, attr), on_update=on_update, on_freeze=on_freeze_func_copy, save_original_on_copy=False
+                )
                 for attr in attrs
             },
             on_update=on_update,
@@ -206,7 +219,7 @@ def __on_update_func(on_update: OnUpdateFuncType) -> OnUpdateFuncType:
         elif on_update == 'warning':
             return __on_update_warning
         elif on_update == 'nothing':
-            return lambda message, *args, **kwargs: None
+            return lambda message, *args, **kwargs: None  # type: ignore[return-value]
         else:
             raise AttributeError(
                 f"Invalid value for on_update parameter, '{on_update}' found, "

--- a/gelidum/frozen/frozen_class_creator.py
+++ b/gelidum/frozen/frozen_class_creator.py
@@ -10,7 +10,7 @@ from gelidum.typing import OnUpdateFuncType
 def __create_frozen_class(
     klass: Type[object], attrs: Iterable[str], on_update_func: OnUpdateFuncType
 ) -> Type[FrozenBase]:
-    camel_case_module = klass.__module__.title().replace('.', '').replace('_', "")
+    camel_case_module = klass.__module__.title().replace('.', '').replace('_', '')
     frozen_class_name = f'Frozen{klass.__name__}From{camel_case_module}'
     frozen_class: Type[FrozenBase] = cast(
         Type[FrozenBase],
@@ -43,7 +43,7 @@ def make_frozen_class(klass: Type[object], attrs: Iterable[str], on_update: OnUp
 
 def make_unique_class(klass: Type[object], attrs: Dict[str, Any], on_update: OnUpdateFuncType) -> Type[FrozenBase]:
 
-    camel_case_module = klass.__module__.title().replace('.', '').replace('_', "")
+    camel_case_module = klass.__module__.title().replace('.', '').replace('_', '')
     unique_suffix = str(uuid.uuid4()).replace('-', '')
     frozen_class_name = f'Frozen{klass.__name__}From{camel_case_module}{unique_suffix}'
     frozen_class: Type[FrozenBase] = cast(

--- a/gelidum/on_freeze.py
+++ b/gelidum/on_freeze.py
@@ -20,7 +20,7 @@ class OnFreezeOriginalObjTracker(OnFreezeCopier):
     frozen. Useful for keeping track of original 'hot' objects.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__original_obj: Optional[Any] = None
 
     def __call__(self, obj: Any) -> Any:

--- a/gelidum/tests/gelidum_tests/test_freeze_functions.py
+++ b/gelidum/tests/gelidum_tests/test_freeze_functions.py
@@ -42,7 +42,7 @@ class TestFreezeFunctions(unittest.TestCase):
         with self.assertRaises(FrozenException) as context:
             frozen_times.factor = 10
 
-        self.assertEqual('Can\'t assign attribute \'factor\' on immutable instance', str(context.exception))
+        self.assertEqual("Can't assign attribute 'factor' on immutable instance", str(context.exception))
 
     def test_freeze_function_and_writing_frozen_attributes_with_exception(self) -> None:
         def times() -> None:

--- a/gelidum/typing.py
+++ b/gelidum/typing.py
@@ -1,25 +1,22 @@
+from __future__ import annotations
+
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Generic,
-    Iterable,
-    Mapping,
     Optional,
-    Reversible,
-    Sized,
     TypeVar,
     Union,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from gelidum.collections import (  # noqa
-        frozendict,
-        frozenlist,
-        frozenndarray,
-        frozenzet,
-    )
-    from gelidum.frozen import FrozenBase  # noqa
+    from gelidum.collections.frozendict import frozendict  # noqa
+    from gelidum.collections.frozenlist import frozenlist  # noqa
+    from gelidum.collections.frozenndarray import frozenndarray  # noqa
+    from gelidum.collections.frozenzet import frozenzet  # noqa
+    from gelidum.frozen.frozen_base import FrozenBase  # noqa
 
 
 T = TypeVar('T')
@@ -29,11 +26,34 @@ class Freezable(Generic[T]):  # noqa
     pass
 
 
-FrozenList = Union['FrozenBase', Sized, Iterable, Reversible, 'frozenlist']
-FrozenDict = Union['FrozenBase', Mapping, 'frozendict']
-FrozenZet = Union['FrozenBase', Sized, Iterable, 'frozenzet']
-FrozenNdArray = Union['FrozenBase', Sized, Iterable, 'frozenndarray']
+class Frozen(Generic[T]):
+    """
+    Generic type representing a frozen (immutable) version of type T.
 
+    This type preserves all attributes and methods of T while ensuring immutability.
+    Use this for type hints to maintain type information through freeze operations.
+
+    Example:
+        person = Person('Alice', 30)
+        frozen_person: Frozen[Person] = freeze(person)
+    """
+
+    pass
+
+
+# TypeAlias is available in Python 3.10+, for 3.9 we use simple assignment
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+
+    FrozenList: TypeAlias = 'frozenlist'
+    FrozenDict: TypeAlias = 'frozendict'
+    FrozenZet: TypeAlias = 'frozenzet'
+    FrozenNdArray: TypeAlias = 'frozenndarray'
+else:
+    FrozenList = 'frozenlist'  # type: ignore[misc]
+    FrozenDict = 'frozendict'  # type: ignore[misc]
+    FrozenZet = 'frozenzet'  # type: ignore[misc]
+    FrozenNdArray = 'frozenndarray'  # type: ignore[misc]
 
 FrozenType = Optional[
     Union[
@@ -44,21 +64,18 @@ FrozenType = Optional[
         complex,
         str,
         bytes,
-        FrozenDict,
-        FrozenList,
-        FrozenZet,
-        FrozenNdArray,
+        FrozenDict,  # type: ignore[valid-type]
+        FrozenList,  # type: ignore[valid-type]
+        FrozenZet,  # type: ignore[valid-type]
+        FrozenNdArray,  # type: ignore[valid-type]
         tuple,
         frozenset,
         'FrozenBase',
-        T,
+        Frozen[T],
     ]
 ]
 
-try:
-    OnUpdateFuncType = Callable[['FrozenBase', str, ...], None]
-except TypeError:
-    OnUpdateFuncType = Callable
+OnUpdateFuncType = Callable[..., None]
 
 
 OnFreezeFuncType = Callable[[Any], Any]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,22 @@
 [project]
 name = "gelidum"
-version = "0.9.1"
+version = "0.10.0"
 description = "Freeze your objects in python"
 readme = "README.md"
 keywords = [ "freeze", "python", "object" ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     { name = "Diego J. Romero López", email = "diegojromerolopez@gmail.com" },
 ]
 classifiers=[
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License"
@@ -37,6 +36,7 @@ dev = [
     "flake8>=7.3.0",
     "flake8-quotes>=3.4.0",
     "isort>=6.0.1",
+    "mypy>=1.18.2",
 ]
 
 [tool.setuptools.packages.find]
@@ -55,3 +55,13 @@ docstring-quotes = '"""'
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = false
+warn_unused_configs = true
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "gelidum.tests.*"
+ignore_errors = true


### PR DESCRIPTION
## Changes

- Fix type hints.
- Removal of support for Python versions < 3.9.

## Disclaimer

- Fix the type hints with the help of Claude Sonnet 4.5.
- Used as an agent with Antigravity.
- Some guidance was provided:
  - Use of generic types.
  - Not ignoring the tests.