### PR TITLE
Specify build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ dev = [
     "mypy>=1.18.2",
 ]
 
+[build-system]
+requires = ["setuptools"]  # PEP 508 specifications.
+build-backend = "setuptools.build_meta:__legacy__"
+
 [tool.setuptools.packages.find]
 include = ["gelidum*"]
 exclude = ["resources*"]


### PR DESCRIPTION
gelidum failed to build in fedora due to not specifying the build-system:
https://bugzilla.redhat.com/show_bug.cgi?id=2397266
This is also discussed in python, that this should not be supported anymore:
https://discuss.python.org/t/do-we-want-to-keep-the-build-system-default-for-pyproject-toml/104759/22
So this might be useful to add, before it causes further breakage.